### PR TITLE
updates for PHP 8.3

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -16,10 +16,9 @@ jobs:
     strategy:
       matrix:
         php-versions:
-          - "7.2"
-          - "7.3"
-          - "7.4"
-          - "8.0"
+          - "8.1"
+          - "8.2"
+          - "8.3"
 
     name: "analytics-campaign-urls build - PHP ${{ matrix.php-versions }}"
 

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /composer.lock
 /vendor
 /.phpunit.result.cache
+.phpunit.cache

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Marcus Jaschen <mjaschen@gmail.com>
+Copyright (c) 2023 Marcus Jaschen <mjaschen@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 # Analytics Campaign URLs
 
-This library allows it to easily append campaign parameters (e. g. for Google Analytics or Piwik) to any given URL.
+This library allows it to easily append campaign parameters (e.g. for Google
+Analytics, Matomo/Piwik or Plausible) to any given URL.
 
 ## Requirements
 
-At least PHP 7.0 is required to use this library. 
+At least PHP 8.1 is required to use this library in the current version.
+
+Version 2.x of this library supports PHP versions 7.0 or higher.
 
 ## Installation
 
@@ -49,7 +52,6 @@ $campaignUrlMatomo = Url::addAnalyticsCampaignParams('https://example.com/', $ma
 
 - [Google Analytics Campaign URL Builder][ga]
 - [Matomo Campaign URL Builder][matomo]
-
 
 [ga]: https://ga-dev-tools.appspot.com/campaign-url-builder/
 [matomo]: https://matomo.org/docs/tracking-campaigns-url-builder/

--- a/composer.json
+++ b/composer.json
@@ -19,13 +19,14 @@
     }
   ],
   "require": {
-    "php": ">=7.0"
+    "php": "^8.1"
   },
   "require-dev": {
-    "ergebnis/composer-normalize": "^2.13",
-    "phpunit/phpunit": "^8.0",
-    "squizlabs/php_codesniffer": "^3.5",
-    "vimeo/psalm": "^4.4"
+    "ergebnis/composer-normalize": "^2.39",
+    "phpunit/phpunit": "^10.0",
+    "squizlabs/php_codesniffer": "^3.7",
+    "vimeo/psalm": "^5.0",
+    "rector/rector": "^0.18.12"
   },
   "autoload": {
     "psr-4": {
@@ -51,5 +52,10 @@
     ],
     "ci:tests": "./vendor/bin/phpunit",
     "ci:validate-composer": "composer validate --no-check-all --strict"
+  },
+  "config": {
+    "allow-plugins": {
+      "ergebnis/composer-normalize": true
+    }
   }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,12 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="phpunit.xsd"
-         bootstrap="tests/bootstrap.php"
-         cacheResult="true"
-         verbose="true">
-    <testsuites>
-        <testsuite name="default">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" bootstrap="tests/bootstrap.php" cacheResult="true" cacheDirectory=".phpunit.cache">
+  <testsuites>
+    <testsuite name="default">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,6 +2,8 @@
 <psalm
     errorLevel="1"
     resolveFromConfigFile="true"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="false"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/src/Parameters/GoogleAnalytics.php
+++ b/src/Parameters/GoogleAnalytics.php
@@ -1,60 +1,22 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MinistryOfWeb\AnalyticsCampaignUrls\Parameters;
 
 class GoogleAnalytics implements ParametersInterface
 {
-    /**
-     * @var string
-     */
-    private $campaign;
-
-    /**
-     * @var string
-     */
-    private $medium;
-
-    /**
-     * @var string
-     */
-    private $source;
-
-    /**
-     * @var string
-     */
-    private $term;
-
-    /**
-     * @var string
-     */
-    private $content;
-
-    /**
-     * Parameters constructor.
-     *
-     * @param string $campaign
-     * @param string $medium
-     * @param string $source
-     * @param string $term
-     * @param string $content
-     */
     public function __construct(
-        string $campaign,
-        string $medium = '',
-        string $source = '',
-        string $term = '',
-        string $content = ''
+        public readonly string $campaign,
+        public readonly string $medium = '',
+        public readonly string $source = '',
+        public readonly string $term = '',
+        public readonly string $content = ''
     ) {
-        $this->campaign = $campaign;
-        $this->medium   = $medium;
-        $this->source   = $source;
-        $this->term     = $term;
-        $this->content  = $content;
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getCampaign(): string
     {
@@ -62,7 +24,7 @@ class GoogleAnalytics implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getMedium(): string
     {
@@ -70,7 +32,7 @@ class GoogleAnalytics implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getSource(): string
     {
@@ -78,7 +40,7 @@ class GoogleAnalytics implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getTerm(): string
     {
@@ -86,7 +48,7 @@ class GoogleAnalytics implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getContent(): string
     {
@@ -104,19 +66,19 @@ class GoogleAnalytics implements ParametersInterface
             'utm_campaign' => $this->campaign,
         ];
 
-        if (! empty($this->medium)) {
+        if (!empty($this->medium)) {
             $params['utm_medium'] = $this->medium;
         }
 
-        if (! empty($this->source)) {
+        if (!empty($this->source)) {
             $params['utm_source'] = $this->source;
         }
 
-        if (! empty($this->term)) {
+        if (!empty($this->term)) {
             $params['utm_term'] = $this->term;
         }
 
-        if (! empty($this->content)) {
+        if (!empty($this->content)) {
             $params['utm_content'] = $this->content;
         }
 

--- a/src/Parameters/Matomo.php
+++ b/src/Parameters/Matomo.php
@@ -1,60 +1,22 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MinistryOfWeb\AnalyticsCampaignUrls\Parameters;
 
 class Matomo implements ParametersInterface
 {
-    /**
-     * @var string
-     */
-    private $campaign;
-
-    /**
-     * @var string
-     */
-    private $medium;
-
-    /**
-     * @var string
-     */
-    private $source;
-
-    /**
-     * @var string
-     */
-    private $keyword;
-
-    /**
-     * @var string
-     */
-    private $content;
-
-    /**
-     * Parameters constructor.
-     *
-     * @param string $campaign
-     * @param string $medium
-     * @param string $source
-     * @param string $keyword
-     * @param string $content
-     */
     public function __construct(
-        string $campaign,
-        string $medium = '',
-        string $source = '',
-        string $keyword = '',
-        string $content = ''
+        public readonly string $campaign,
+        public readonly string $medium = '',
+        public readonly string $source = '',
+        public readonly string $keyword = '',
+        public readonly string $content = ''
     ) {
-        $this->campaign = $campaign;
-        $this->medium   = $medium;
-        $this->source   = $source;
-        $this->keyword  = $keyword;
-        $this->content  = $content;
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getCampaign(): string
     {
@@ -62,7 +24,7 @@ class Matomo implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getMedium(): string
     {
@@ -70,7 +32,7 @@ class Matomo implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getSource(): string
     {
@@ -78,7 +40,7 @@ class Matomo implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getKeyword(): string
     {
@@ -86,7 +48,7 @@ class Matomo implements ParametersInterface
     }
 
     /**
-     * @return string
+     * @deprecated use property instead
      */
     public function getContent(): string
     {
@@ -104,19 +66,19 @@ class Matomo implements ParametersInterface
             'pk_campaign' => $this->campaign,
         ];
 
-        if (! empty($this->medium)) {
+        if (!empty($this->medium)) {
             $params['pk_medium'] = $this->medium;
         }
 
-        if (! empty($this->source)) {
+        if (!empty($this->source)) {
             $params['pk_source'] = $this->source;
         }
 
-        if (! empty($this->keyword)) {
+        if (!empty($this->keyword)) {
             $params['pk_kwd'] = $this->keyword;
         }
 
-        if (! empty($this->content)) {
+        if (!empty($this->content)) {
             $params['pk_content'] = $this->content;
         }
 

--- a/src/Parameters/ParametersInterface.php
+++ b/src/Parameters/ParametersInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MinistryOfWeb\AnalyticsCampaignUrls\Parameters;
@@ -8,8 +9,6 @@ interface ParametersInterface
     /**
      * Creates the associative array of URL parameters (key = parameter name;
      * value = paramater value).
-     *
-     * @return array
      */
     public function toArray(): array;
 }

--- a/src/Parameters/Piwik.php
+++ b/src/Parameters/Piwik.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MinistryOfWeb\AnalyticsCampaignUrls\Parameters;

--- a/src/Url.php
+++ b/src/Url.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace MinistryOfWeb\AnalyticsCampaignUrls;
@@ -7,17 +8,11 @@ use MinistryOfWeb\AnalyticsCampaignUrls\Parameters\ParametersInterface;
 
 class Url
 {
-    /**
-     * @param string $url
-     * @param ParametersInterface $parameters
-     *
-     * @return string
-     */
     public static function addAnalyticsCampaignParams(string $url, ParametersInterface $parameters): string
     {
         $query = http_build_query($parameters->toArray());
 
-        if (strpos($url, '?') === false) {
+        if (!str_contains($url, '?')) {
             return $url . '?' . $query;
         }
 


### PR DESCRIPTION
- remove support for PHP versions < 8.1
- use constructor property promotion
- deprecate getters (use properties instead)
- update test matrix for GitHub Actions
- update README